### PR TITLE
[DEN-241] Customer Origin Resource bug fix and example update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=terraform-providers
 NAME=ec
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.3
+VERSION=0.4.4
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Reference this provider in a Terraform Configuration file (e.g. `main.tf`):
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }
@@ -108,7 +108,7 @@ Example:
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "github.com/terraform-providers/ec"
     }
   }

--- a/docs/resources/origin.md
+++ b/docs/resources/origin.md
@@ -15,7 +15,7 @@ description: |-
 ```terraform
 resource "ec_origin" "origin_images_httplarge" {
     account_number = "A1234"
-    directory_name = "/images"
+    directory_name = "images"
     host_header = "images.exampleorigin.com:443"
     media_type_id = 3 # 3: HTTP Large, 8: HTTP Small, 14: ADN
     network_configuration = 1 # 1: default, 2: IPv6 preferred, 3: IPv4 preferred, 4: IPv4 only, 5: IPv6 only
@@ -44,15 +44,19 @@ resource "ec_origin" "origin_images_httplarge" {
     shield_pop {
         pop_code = "LAA"
     }
+
+    shield_pop {
+        pop_code = "LHB"
+    }
 }
 
 resource "ec_origin" "origin_cart_adn" {
     account_number = "A1234"
-    directory_name = "/shopping"
+    directory_name = "shopping"
     host_header = "cart.exampleorigin.com:443"
     media_type_id = 14 # 3: HTTP Large, 8: HTTP Small, 14: ADN
     network_configuration = 1 # 1: default, 2: IPv6 preferred, 3: IPv4 preferred, 4: IPv4 only, 5: IPv6 only
-    follow_redirects = true
+    follow_redirects = false
     validation_url = "https://cart.exampleorigin.com/logo.jpg"
     load_balancing_scheme_http = "PF" # RR: Round Robin  PF: Primary/Failover.
     origin_hostname_http {
@@ -84,6 +88,9 @@ resource "ec_origin" "origin_cart_adn" {
 
 ### Required
 
+- **account_number** (String) Account Number associated with the customer whose 
+				origins you wish to manage. This account number may be found in 
+				the upper right-hand corner of the MCC.
 - **directory_name** (String) Identifies the directory name that will be 
 				assigned to the customer origin configuration. This alphanumeric 
 				value is appended to the end of the base CDN URL that points to 
@@ -112,8 +119,6 @@ resource "ec_origin" "origin_cart_adn" {
 
 ### Optional
 
-- **account_number** (String) Account Number for the customer if not already 
-				specified in the provider configuration.
 - **follow_redirects** (Boolean) Indicates whether our edge servers will respect a 
 				URL redirect when validating the set of optimal ADN gateway 
 				servers for your customer origin configuration.

--- a/ec/provider.go
+++ b/ec/provider.go
@@ -24,7 +24,7 @@ const (
 	idsURLProd       string = "https://id.vdms.io"
 
 	// Version indicates the current version of this provider
-	Version string = "0.4.3"
+	Version string = "0.4.4"
 
 	userAgentFormat = "edgecast/terraform-provider:%s"
 )

--- a/ec/resources/origin/origin.go
+++ b/ec/resources/origin/origin.go
@@ -63,8 +63,9 @@ func ResourceOrigin() *schema.Resource {
 			"account_number": {
 				Type:     schema.TypeString,
 				Required: true,
-				Description: `Account Number for the customer if not already 
-				specified in the provider configuration.`,
+				Description: `Account Number associated with the customer whose 
+				origins you wish to manage. This account number may be found in 
+				the upper right-hand corner of the MCC.`,
 			},
 			"directory_name": {
 				Type:     schema.TypeString,

--- a/ec/resources/origin/origin.go
+++ b/ec/resources/origin/origin.go
@@ -62,7 +62,7 @@ func ResourceOrigin() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"account_number": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				Description: `Account Number for the customer if not already 
 				specified in the provider configuration.`,
 			},

--- a/examples/resources/ec_customer/main.tf
+++ b/examples/resources/ec_customer/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_customer_user/main.tf
+++ b/examples/resources/ec_customer_user/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_dns_group/main.tf
+++ b/examples/resources/ec_dns_group/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_dns_masterservergroup/main.tf
+++ b/examples/resources/ec_dns_masterservergroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_dns_secondaryzonegroup/main.tf
+++ b/examples/resources/ec_dns_secondaryzonegroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_dns_zone/main.tf
+++ b/examples/resources/ec_dns_zone/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_edgecname/main.tf
+++ b/examples/resources/ec_edgecname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_origin/main.tf
+++ b/examples/resources/ec_origin/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_origin/resource.tf
+++ b/examples/resources/ec_origin/resource.tf
@@ -1,6 +1,6 @@
 resource "ec_origin" "origin_images_httplarge" {
     account_number = "A1234"
-    directory_name = "/images"
+    directory_name = "images"
     host_header = "images.exampleorigin.com:443"
     media_type_id = 3 # 3: HTTP Large, 8: HTTP Small, 14: ADN
     network_configuration = 1 # 1: default, 2: IPv6 preferred, 3: IPv4 preferred, 4: IPv4 only, 5: IPv6 only
@@ -29,15 +29,19 @@ resource "ec_origin" "origin_images_httplarge" {
     shield_pop {
         pop_code = "LAA"
     }
+
+    shield_pop {
+        pop_code = "LHB"
+    }
 }
 
 resource "ec_origin" "origin_cart_adn" {
     account_number = "A1234"
-    directory_name = "/shopping"
+    directory_name = "shopping"
     host_header = "cart.exampleorigin.com:443"
     media_type_id = 14 # 3: HTTP Large, 8: HTTP Small, 14: ADN
     network_configuration = 1 # 1: default, 2: IPv6 preferred, 3: IPv4 preferred, 4: IPv4 only, 5: IPv6 only
-    follow_redirects = true
+    follow_redirects = false
     validation_url = "https://cart.exampleorigin.com/logo.jpg"
     load_balancing_scheme_http = "PF" # RR: Round Robin  PF: Primary/Failover.
     origin_hostname_http {

--- a/examples/resources/ec_rules_engine_policy/main.tf
+++ b/examples/resources/ec_rules_engine_policy/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_waf_access_rule/main.tf
+++ b/examples/resources/ec_waf_access_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_waf_custom_rule_set/main.tf
+++ b/examples/resources/ec_waf_custom_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_waf_managed_rule/main.tf
+++ b/examples/resources/ec_waf_managed_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_waf_rate_rule/main.tf
+++ b/examples/resources/ec_waf_rate_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/examples/resources/ec_waf_scopes/main.tf
+++ b/examples/resources/ec_waf_scopes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ec = {
-      version = "0.4.3"
+      version = "0.4.4"
       source  = "EdgeCast/ec"
     }
   }

--- a/install_win.bat
+++ b/install_win.bat
@@ -9,7 +9,7 @@ set HOSTNAME=github.com
 set NAMESPACE=terraform-providers
 set NAME=ec
 set BINARY=terraform-provider-%NAME%.exe
-set VERSION=0.4.3
+set VERSION=0.4.4
 set OS_ARCH=windows_amd64
 
 go build


### PR DESCRIPTION
1) Updated ec_origin schema to require account_number property to be defined in resource. 
2) Updated resources/ec_origin example resource.tf file to not have preceding / for directory_name and included a few more defined properties to enhance the example.
3) Changes to prepare for 0.4.4 release. 